### PR TITLE
Site pages + routing, SEO/OG defaults, Vercel Analytics, sitemap/robots

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <!-- PWA / App -->
     <link rel="manifest" href="/site.webmanifest" />
-    <meta name="theme-color" content="#0f1216" />
-    <script>     
+    <meta name="color-scheme" content="dark light" />
+    <meta name="theme-color" content="#0f1216" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#ffffff"   media="(prefers-color-scheme: light)" />
+
+    <!-- Wowhead tooltips -->
+    <script>
       var whTooltips = {
         colorLinks: false,
         iconizeLinks: false,
@@ -15,40 +21,45 @@
     </script>
     <script defer src="https://wow.zamimg.com/js/tooltips.js"></script>
 
-    <!-- Title + SEO -->
+    <!-- Preconnects for icons/tooltips -->
+    <link rel="preconnect" href="https://wow.zamimg.com" crossorigin>
+    <link rel="dns-prefetch" href="//wow.zamimg.com">
+    <link rel="preconnect" href="https://render.worldofwarcraft.com" crossorigin>
+    <link rel="dns-prefetch" href="//render.worldofwarcraft.com">
+
+    <!-- Primary SEO -->
     <title>GearForge — Optimize Your Gear</title>
     <meta name="description" content="GearForge helps you analyze, compare, and optimize your gear with fast, clear recommendations." />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="%VITE_SITE_URL%" />
 
-    <!-- Favicons (matching your /public files) -->
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="GearForge" />
+    <meta property="og:title" content="GearForge — Optimize Your Gear" />
+    <meta property="og:description" content="Optimize your gear. Maximize your potential." />
+    <meta property="og:url" content="%VITE_SITE_URL%" />
+    <meta property="og:image" content="%VITE_OG_IMAGE%" />
+    <meta property="og:image:alt" content="GearForge upgrade planner and seasonal tracker preview" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="GearForge — Optimize Your Gear" />
+    <meta name="twitter:description" content="Optimize your gear. Maximize your potential." />
+    <meta name="twitter:image" content="%VITE_OG_IMAGE%" />
+    <!-- <meta name="twitter:site" content="@your_handle" /> -->
+
+    <!-- Icons -->
     <link rel="icon" href="/favicon.ico" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
     <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
-    <meta name="theme-color" content="#0f1216" />
-
-    <link rel="preconnect" href="https://render.worldofwarcraft.com" crossorigin>
-    <link rel="dns-prefetch" href="https://render.worldofwarcraft.com">
-
-
-    <!-- Open Graph -->
-    <meta property="og:site_name" content="GearForge" />
-    <meta property="og:title" content="GearForge" />
-    <meta property="og:description" content="Optimize your gear. Maximize your potential." />
-    <meta property="og:type" content="website" />
-    <meta property="og:image" content="/og-cover.png" />
-    <!-- (Optional) replace with absolute URL in prod for best previews -->
-    <!-- <meta property="og:url" content="https://your-domain.com/" /> -->
-
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="GearForge" />
-    <meta name="twitter:description" content="Optimize your gear. Maximize your potential." />
-    <meta name="twitter:image" content="/og-cover.png" />
   </head>
   <body>
     <div id="root"></div>
+    <!-- Make sure this path matches your actual entry (you used /src/main.tsx earlier) -->
     <script type="module" src="/src/app/main.tsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gearforge",
       "version": "0.0.0",
       "dependencies": {
+        "@vercel/analytics": "^1.5.0",
         "clsx": "^2.1.1",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -2425,6 +2426,44 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vercel/blob": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@vercel/analytics": "^1.5.0",
     "clsx": "^2.1.1",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 # robots.txt for GearForge
 User-agent: *
 Allow: /
+
+Sitemap: https://gearforge.vercel.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://gearforge.vercel.app/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://gearforge.vercel.app/optimizer</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://gearforge.vercel.app/guides</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://gearforge.vercel.app/faq</loc><changefreq>monthly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://gearforge.vercel.app/terms</loc><changefreq>yearly</changefreq><priority>0.2</priority></url>
+  <url><loc>https://gearforge.vercel.app/privacy</loc><changefreq>yearly</changefreq><priority>0.2</priority></url>
+</urlset>

--- a/src/app/LandingPage.tsx
+++ b/src/app/LandingPage.tsx
@@ -4,15 +4,12 @@ import { Link } from "react-router-dom";
 
 export function LandingPage() {
   usePageMeta({
-    title: "GearForge — Smarter WoW gear decisions",
-    description:
-      "Paste your SimC and get clear, prioritized upgrade plans with crest costs, caps, and drop ceilings.",
-    ogTitle: "GearForge",
-    ogDescription: "Forge the perfect setup.",
-    ogImage: "/images/og/gearforge-wide-dark.png",
-    canonical: typeof window !== "undefined" ? window.location.href : "https://gearforge.app",
+    title: "Upgrade Planner",
+    description: "Plan your WoW upgrades from a SimC export. See crest/FS costs and free watermarks.",
+    canonical: "/optimizer",
+    image: "/og/optimizer.png",
+    ogType: "website",
   });
-
 
   return (
     <main className={`${page.wrap} ${page.wrapWide}`}>

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -1,12 +1,17 @@
 // src/app/main.tsx
-import { StrictMode } from "react";
+import { StrictMode, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { router } from "./routes";
 import "./index.css";
+import { inject } from "@vercel/analytics";
+
+if (import.meta.env.PROD) inject();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <Suspense fallback={<div style={{ padding: 24 }}>Loading…</div>}>
+      <RouterProvider router={router} />
+    </Suspense>
   </StrictMode>
 );

--- a/src/app/pages/NotFoundPage.tsx
+++ b/src/app/pages/NotFoundPage.tsx
@@ -1,0 +1,8 @@
+export default function NotFoundPage() {
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>404</h1>
+      <p>Page not found.</p>
+    </main>
+  );
+}

--- a/src/app/pages/faq/FaqPage.tsx
+++ b/src/app/pages/faq/FaqPage.tsx
@@ -1,0 +1,29 @@
+import { usePageMeta } from "../../seo/usePageMeta";
+
+const faqs = [
+  { q: "What is GearForge?", a: "A WoW gearing assistant for upgrades, crest/FS costs, and seasonal tracking." },
+  { q: "Do I need to log in?", a: "No—paste your SimC export and analyze locally in your browser." },
+];
+
+export default function FaqPage() {
+  usePageMeta({
+    title: "FAQ",
+    description: "Frequently asked questions about GearForge.",
+    canonical: "/faq",
+    noindex: true,
+  });
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>FAQ</h1>
+      <div style={{ display: "grid", gap: 12, marginTop: 12 }}>
+        {faqs.map((f, i) => (
+          <details key={i}>
+            <summary style={{ cursor: "pointer" }}>{f.q}</summary>
+            <div style={{ marginTop: 8, color: "#9ca3af" }}>{f.a}</div>
+          </details>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/pages/guides/GuidesPage.tsx
+++ b/src/app/pages/guides/GuidesPage.tsx
@@ -1,0 +1,17 @@
+import { usePageMeta } from "../../seo/usePageMeta"; // adjust path if different
+
+export default function GuidesPage() {
+  usePageMeta({
+    title: "Guides",
+    description: "Class & gearing guides (coming soon).",
+    canonical: "/guides",
+    noindex: true,
+  });
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>Guides</h1>
+      <p>We’re working on class- and gearing-focused guides. Check back soon.</p>
+    </main>
+  );
+}

--- a/src/app/pages/legal/PrivacyPage.tsx
+++ b/src/app/pages/legal/PrivacyPage.tsx
@@ -1,0 +1,17 @@
+import { SimpleDocPage } from "./SimpleDocPage";
+
+export default function PrivacyPage() {
+  return (
+    <SimpleDocPage
+      title="Privacy Policy"
+      description="How GearForge handles data."
+      canonical="/privacy"
+      noindex
+    >
+      <p><em>Last updated: {new Date().toISOString().slice(0,10)}</em></p>
+      <p>We process your SimC text locally in your browser. We do not store your character data.</p>
+      <p>We may collect anonymous analytics (page views, perf metrics) to improve the site.</p>
+      <p>Questions? Email: hello@your-domain</p>
+    </SimpleDocPage>
+  );
+}

--- a/src/app/pages/legal/SimpleDocPage.tsx
+++ b/src/app/pages/legal/SimpleDocPage.tsx
@@ -1,0 +1,27 @@
+// src/app/pages/legal/SimpleDocPage.tsx
+import type { PropsWithChildren } from "react";
+import { usePageMeta } from "../../seo/usePageMeta";
+
+type SimpleDocProps = PropsWithChildren<{
+  title: string;
+  description: string;
+  canonical: string;
+  noindex?: boolean;
+}>;
+
+export function SimpleDocPage({
+  title,
+  description,
+  canonical,
+  noindex = true,
+  children,
+}: SimpleDocProps) {
+  usePageMeta({ title, description, canonical, noindex });
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>{title}</h1>
+      <div style={{ marginTop: 12 }}>{children}</div>
+    </main>
+  );
+}

--- a/src/app/pages/legal/TermsPage.tsx
+++ b/src/app/pages/legal/TermsPage.tsx
@@ -1,0 +1,20 @@
+import { SimpleDocPage } from "./SimpleDocPage";
+
+export default function TermsPage() {
+  return (
+    <SimpleDocPage
+      title="Terms of Service"
+      description="Terms of Service for GearForge."
+      canonical="/terms"
+      noindex
+    >
+      <p><em>Last updated: {new Date().toISOString().slice(0,10)}</em></p>
+      <h2>1. Acceptance</h2><p>By using GearForge, you agree to these terms.</p>
+      <h2>2. Use</h2><p>Personal, non-commercial use. Don’t abuse the service.</p>
+      <h2>3. Data</h2><p>SimC input is processed client-side; we don’t store your character data.</p>
+      <h2>4. Warranty &amp; Liability</h2><p>Provided “as is”.</p>
+      <h2>5. Changes</h2><p>We may update these terms.</p>
+      <h2>6. Contact</h2><p>Email: hello@your-domain</p>
+    </SimpleDocPage>
+  );
+}

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,23 +1,37 @@
 // src/app/routes.tsx
 import { createBrowserRouter } from "react-router-dom";
 import { RootLayout } from "./RootLayout";
+import { LandingPage } from "./LandingPage";
 import { OptimizerPage } from "../features/optimizer/pages/OptimizerPage";
 import OptimizerResultPage from "../features/optimizer/pages/OptimizerResultPage";
-import { LandingPage } from "./LandingPage";
+
+/* eslint-disable react-refresh/only-export-components */
+// Route-level lazy loaders (each returns { Component })
+const GuidesPage  = () => import("./pages/guides/GuidesPage").then(m => ({ Component: m.default }));
+const FaqPage     = () => import("./pages/faq/FaqPage").then(m => ({ Component: m.default }));
+const TermsPage   = () => import("./pages/legal/TermsPage").then(m => ({ Component: m.default }));
+const PrivacyPage = () => import("./pages/legal/PrivacyPage").then(m => ({ Component: m.default }));
+const NotFound    = () => import("./pages/NotFoundPage").then(m => ({ Component: m.default }));
+/* eslint-enable react-refresh/only-export-components */
 
 export const router = createBrowserRouter([
   {
     element: <RootLayout />,
     children: [
-      { path: "/", element: <LandingPage /> },
-      { path: "/optimizer", element: <OptimizerPage /> },
-      { path: "/optimizer/view", element: <OptimizerResultPage /> },
+      { index: true, element: <LandingPage /> },
 
-      // later extras:
-      // { path: "/guides", element: <GuidesIndexPage /> },
-      // { path: "/guides/:slug", element: <GuidePage /> },
-      // { path: "/blog", element: <BlogIndexPage /> },
-      // { path: "/blog/:slug", element: <BlogPostPage /> },
+      // Feature: Optimizer
+      { path: "optimizer", element: <OptimizerPage /> },
+      { path: "optimizer/view", element: <OptimizerResultPage /> },
+
+      // Site pages (lazy)
+      { path: "guides",  lazy: GuidesPage },
+      { path: "faq",     lazy: FaqPage },
+      { path: "terms",   lazy: TermsPage },
+      { path: "privacy", lazy: PrivacyPage },
+
+      // 404
+      { path: "*", lazy: NotFound },
     ],
   },
 ]);

--- a/src/app/seo/usePageMeta.ts
+++ b/src/app/seo/usePageMeta.ts
@@ -1,50 +1,143 @@
 import { useEffect } from "react";
 
-function upsert(selector: string, tag: "meta" | "link", attrs: Record<string, string>) {
-  let el = document.head.querySelector<Element>(selector);
-  if (!el) {
-    el = document.createElement(tag);
-    document.head.appendChild(el);
+type OgType = "website" | "article";
+
+export type UsePageMetaOpts = {
+  /** Page title without site suffix (we’ll template it) */
+  title?: string;
+  /** Plain text description (150–160 chars is ideal) */
+  description?: string;
+  /** Absolute or relative URL to an OG image */
+  image?: string;
+  /** Absolute or relative canonical URL; defaults to current pathname */
+  canonical?: string;
+  /** Set robots to noindex,nofollow */
+  noindex?: boolean;
+  /** Open Graph type; default "website" */
+  ogType?: OgType;
+  /** Optional JSON-LD object */
+  jsonLd?: object;
+  /** Title template; %s replaced by title */
+  titleTemplate?: string; // e.g. "%s — GearForge"
+};
+
+const SITE_URL = import.meta.env.VITE_SITE_URL || "";
+const DEFAULT_OG = import.meta.env.VITE_OG_IMAGE || "/og-cover.png";
+const DEFAULT_TEMPLATE = "%s — GearForge";
+
+function abs(url?: string): string | undefined {
+  if (!url) return undefined;
+  try {
+    const base = SITE_URL || (typeof window !== "undefined" ? window.location.origin : "");
+    return new URL(url, base).toString();
+  } catch {
+    return url;
   }
-  Object.entries(attrs).forEach(([k, v]) => el!.setAttribute(k, v));
 }
 
-export function usePageMeta(opts: {
-  title?: string;
-  description?: string;
-  ogTitle?: string;
-  ogDescription?: string;
-  ogImage?: string;
-  canonical?: string;
-  robots?: string;
-}) {
+function selectMeta(attr: "name" | "property", key: string) {
+  return document.head.querySelector<HTMLMetaElement>(`meta[${attr}="${key}"]`);
+}
+
+function upsertMeta(attr: "name" | "property", key: string, content?: string) {
+  if (typeof document === "undefined") return;
+  const el = selectMeta(attr, key);
+  if (!content) {
+    // Only clear if we previously managed it
+    if (el?.dataset.dgrp === "seo") el.remove();
+    return;
+  }
+  if (el) {
+    el.setAttribute("content", content);
+    // keep existing element (may be from index.html)
+    return;
+  }
+  const meta = document.createElement("meta");
+  meta.setAttribute(attr, key);
+  meta.setAttribute("content", content);
+  meta.dataset.dgrp = "seo";
+  document.head.appendChild(meta);
+}
+
+function upsertLinkCanonical(href?: string) {
+  if (typeof document === "undefined") return;
+  let el = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (!href) {
+    if (el?.dataset.dgrp === "seo") el.remove();
+    return;
+  }
+  if (!el) {
+    el = document.createElement("link");
+    el.rel = "canonical";
+    el.dataset.dgrp = "seo";
+    document.head.appendChild(el);
+  }
+  el.href = href;
+}
+
+function upsertJsonLd(data?: object) {
+  if (typeof document === "undefined") return;
+  document
+    .querySelectorAll('script[type="application/ld+json"][data-dgrp="seo"]')
+    .forEach((n) => n.remove());
+  if (!data) return;
+  const el = document.createElement("script");
+  el.type = "application/ld+json";
+  el.dataset.dgrp = "seo";
+  el.text = JSON.stringify(data);
+  document.head.appendChild(el);
+}
+
+export function usePageMeta(opts: UsePageMetaOpts) {
+  const {
+    title,
+    description,
+    image,
+    canonical,
+    noindex,
+    ogType = "website",
+    jsonLd,
+    titleTemplate = DEFAULT_TEMPLATE,
+  } = opts;
+
   useEffect(() => {
-    if (opts.title) document.title = opts.title;
+    if (typeof document === "undefined") return;
 
-    if (opts.description)
-      upsert('meta[name="description"]', "meta", { name: "description", content: String(opts.description) });
+    // Title (+ template)
+    if (title) {
+      const full = titleTemplate.replace("%s", title);
+      document.title = full;
+      upsertMeta("property", "og:title", full);
+      upsertMeta("name", "twitter:title", full);
+    }
 
-    if (opts.ogTitle)
-      upsert('meta[property="og:title"]', "meta", { property: "og:title", content: String(opts.ogTitle) });
+    // Description
+    upsertMeta("name", "description", description);
+    upsertMeta("property", "og:description", description);
+    upsertMeta("name", "twitter:description", description);
 
-    if (opts.ogDescription)
-      upsert('meta[property="og:description"]', "meta", { property: "og:description", content: String(opts.ogDescription) });
+    // Canonical & URL (absolute)
+    const canonicalAbs = abs(canonical ?? (typeof window !== "undefined" ? window.location.pathname : "/"));
+    upsertLinkCanonical(canonicalAbs);
+    upsertMeta("property", "og:url", canonicalAbs || undefined);
 
-    if (opts.ogImage)
-      upsert('meta[property="og:image"]', "meta", { property: "og:image", content: String(opts.ogImage) });
+    // OG image / Twitter image (absolute, with fallback)
+    const imgAbs = abs(image || DEFAULT_OG);
+    upsertMeta("property", "og:image", imgAbs);
+    upsertMeta("name", "twitter:image", imgAbs);
 
-    if (opts.canonical)
-      upsert('link[rel="canonical"]', "link", { rel: "canonical", href: String(opts.canonical) });
+    // OG type + site_name (static site name; override if needed)
+    upsertMeta("property", "og:type", ogType);
+    upsertMeta("property", "og:site_name", "GearForge");
 
-    if (opts.robots)
-      upsert('meta[name="robots"]', "meta", { name: "robots", content: String(opts.robots) });
-  }, [
-    opts.title,
-    opts.description,
-    opts.ogTitle,
-    opts.ogDescription,
-    opts.ogImage,
-    opts.canonical,
-    opts.robots,
-  ]);
+    // Twitter card type
+    upsertMeta("name", "twitter:card", imgAbs ? "summary_large_image" : "summary");
+
+    // robots
+    if (noindex) upsertMeta("name", "robots", "noindex, nofollow");
+    else upsertMeta("name", "robots", undefined);
+
+    // JSON-LD
+    upsertJsonLd(jsonLd);
+  }, [title, description, image, canonical, noindex, ogType, jsonLd, titleTemplate]);
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,17 @@
+// src/components/Header.tsx
 import { Link, NavLink } from "react-router-dom";
 import { Menu } from "lucide-react";
 import c from "./components.module.css";
+
+type NavItem = { label: string; to: string; end?: boolean };
+
+const NAV: NavItem[] = [
+  { label: "Home", to: "/", end: true },
+  { label: "Optimizer", to: "/optimizer" }, // stays active for /optimizer/view
+  { label: "Guides", to: "/guides" },
+  { label: "FAQ", to: "/faq" },
+  // add { label: "Terms", to: "/terms" } or "Privacy" if you want them in top nav
+];
 
 export function Header() {
   return (
@@ -13,16 +24,16 @@ export function Header() {
 
         {/* Desktop nav */}
         <nav className={c.nav} aria-label="Primary">
-          {["Home", "Tools", "Guides", "About"].map((item) => (
+          {NAV.map((item) => (
             <NavLink
-              key={item}
-              to={item === "Home" ? "/" : `/${item.toLowerCase()}`}
+              key={item.to}
+              to={item.to}
+              end={item.end}
               className={({ isActive }) =>
                 isActive ? `${c.navLink} ${c.navLinkActive}` : c.navLink
               }
-              end={item === "Home"}
             >
-              {item}
+              {item.label}
             </NavLink>
           ))}
         </nav>

--- a/src/features/optimizer/pages/OptimizerPage.tsx
+++ b/src/features/optimizer/pages/OptimizerPage.tsx
@@ -6,13 +6,13 @@ import { encodeToUrlHash } from "../services/urlCodec";
 
 export function OptimizerPage() {
   usePageMeta({
-    title: "GearForge — Optimize Your Gear",
-    description: "Paste your SimC (or export) to analyze upgrades, compare slots, and get fast, clear recommendations.",
-    ogTitle: "GearForge",
-    ogDescription: "Forge the perfect setup.",
-    ogImage: "/images/og/gearforge-wide-dark.png",
-    canonical: typeof window !== "undefined" ? window.location.href : "https://gearforge.app",
+    title: "Upgrade Planner",
+    description: "Plan your WoW upgrades from a SimC export. See crest/FS costs and free watermarks.",
+    canonical: "/optimizer",
+    image: "/og/optimizer.png",
+    ogType: "website",
   });
+
 
   const [rawInput, setRawInput] = useState("");
   const [isParsing, setIsParsing] = useState(false);
@@ -26,8 +26,6 @@ export function OptimizerPage() {
     try {
       const simc = rawInput.trim();
       if (!simc) throw new Error("Paste your SimC first.");
-
-      // ✅ encodeToUrlHash already returns "#d=..."
       const fragment = encodeToUrlHash({ simc });
       navigate(`/optimizer/view${fragment}`);
     } catch (err) {

--- a/src/features/optimizer/pages/OptimizerResultPage.tsx
+++ b/src/features/optimizer/pages/OptimizerResultPage.tsx
@@ -21,14 +21,13 @@ const titleCase = (s?: string | null) =>
 
 export default function OptimizerResultPage() {
   usePageMeta({
-    title: "GearForge — Optimize Your Gear",
-    description:
-      "Paste your SimC (or export) to analyze upgrades, compare slots, and get fast, clear recommendations.",
-    ogTitle: "GearForge",
-    ogDescription: "Forge the perfect setup.",
-    ogImage: "/images/og/gearforge-wide-dark.png",
-    canonical: typeof window !== "undefined" ? window.location.href : "https://gearforge.app",
+    title: "Upgrade Planner",
+    description: "Plan your WoW upgrades from a SimC export. See crest/FS costs and free watermarks.",
+    canonical: "/optimizer",
+    image: "/og/optimizer.png",
+    ogType: "website",
   });
+
 
   const data: SimcPayload | null = useMemo(() => {
     if (typeof window === "undefined") return null;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/$1" },
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
Summary
-------

This PR rounds out the app shell and platform bits: adds top-level **site pages** (Guides, FAQ, Terms, Privacy), wires **routing** with lazy loading and a **404**, upgrades **SEO defaults** (canonical + OG/Twitter), enables **Vercel Analytics** via `inject()`, and provides a **sitemap** referenced by **robots.txt**.

What's included
---------------

### Pages & Routing

-   New pages (minimal stubs for now):

    -   `/guides`, `/faq`, `/terms`, `/privacy`

-   Router (`createBrowserRouter`):

    -   Home as `index: true`

    -   Optimizer routes unchanged (`/optimizer`, `/optimizer/view`)

    -   **Lazy** route loaders for the new site pages

    -   404 catch-all route

-   App entry wrapped in `<Suspense>` with a small fallback (`Loading...`) for lazy chunks.

### Header / Navigation

-   Header nav updated to: **Home / Optimizer / Guides / FAQ**

-   Active state preserved for nested optimizer routes.

### SEO & Head

-   `index.html`:

    -   Canonical URL, robots, OG/Twitter card defaults

    -   Dark/light `theme-color`

    -   Preconnect/dns-prefetch for `wow.zamimg.com` and `render.worldofwarcraft.com`

    -   Icons/manifest kept at root

-   `usePageMeta` hook:

    -   Per-route title/description/canonical, OG/Twitter image, robots, optional JSON-LD

    -   New pages use `noindex: true` until content is ready

### Analytics

-   `@vercel/analytics` via `inject()` in `main.tsx` (production-only).

-   Compatible with React Router SPA navigations; no manual pageview calls.

### Public files

-   **`public/sitemap.xml`** with absolute URLs:

    -   `/`, `/optimizer`, `/guides`, `/faq`, `/terms`, `/privacy`

-   **`public/robots.txt`** now points to the sitemap.